### PR TITLE
Update the links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LSPosed Framework
 
-[![Build](https://img.shields.io/github/actions/workflow/status/JingMatrix/LSPosed/core.yml?branch=master&event=push&logo=github&label=Build)](https://github.com/JingMatrix/LSPosed/actions/workflows/core.yml?query=event%3Apush+branch%3Amaster+is%3Acompleted) [![Crowdin](https://img.shields.io/badge/Localization-Crowdin-blueviolet?logo=Crowdin)](https://crowdin.com/project/lsposed_jingmatrix) [![Download](https://img.shields.io/github/v/release/JingMatrix/LSPosed?color=orange&logoColor=orange&label=Download&logo=DocuSign)](https://github.com/JingMatrix/LSPosed/releases/latest) [![Total](https://shields.io/github/downloads/JingMatrix/LSPosed/total?logo=Bookmeter&label=Counts&logoColor=yellow&color=yellow)](https://github.com/JingMatrix/LSPosed/releases)
+[![Build](https://img.shields.io/github/actions/workflow/status/ThePedroo/ReLSPosed/core.yml?branch=master&event=push&logo=github&label=Build)](https://github.com/ThePedroo/ReLSPosed/actions/workflows/core.yml?query=event%3Apush+branch%3Amaster+is%3Acompleted) [![Crowdin](https://img.shields.io/badge/Localization-Crowdin-blueviolet?logo=Crowdin)](https://crowdin.com/project/lsposed_jingmatrix) [![Download](https://img.shields.io/github/v/release/ThePedroo/ReLSPosed?color=orange&logoColor=orange&label=Download&logo=DocuSign)](https://github.com/ThePedroo/ReLSPosed/releases/latest) [![Total](https://shields.io/github/downloads/ThePedroo/ReLSPosed/total?logo=Bookmeter&label=Counts&logoColor=yellow&color=yellow)](https://github.com/ThePedroo/ReLSPosed/releases)
 
 ## Introduction 
 
@@ -22,8 +22,8 @@ Android 8.1 ~ 16
 
 ## Download
 
-- For stable releases, please go to [Github Releases page](https://github.com/JingMatrix/LSPosed/releases)
-- For canary build, please check [Github Actions](https://github.com/JingMatrix/LSPosed/actions/workflows/core.yml?query=branch%3Amaster)
+- For stable releases, please go to [Github Releases page](https://github.com/ThePedroo/ReLSPosed/releases)
+- For canary build, please check [Github Actions](https://github.com/ThePedroo/ReLSPosed/actions/workflows/core.yml?query=branch%3Amaster)
 
 Note: debug builds are only available in Github Actions.
 


### PR DESCRIPTION
All of the Links on the README are leading to JingMatrix's LSPosed. This commit makes every link lead to the JingMatrix page, except for the Crowdin link.