### PR TITLE
Add missing callers to deoptimize

### DIFF
--- a/core/src/main/java/org/lsposed/lspd/deopt/InlinedMethodCallers.java
+++ b/core/src/main/java/org/lsposed/lspd/deopt/InlinedMethodCallers.java
@@ -20,6 +20,7 @@
 
 package org.lsposed.lspd.deopt;
 
+import android.app.Instrumentation;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.res.AssetManager;
@@ -55,6 +56,9 @@ public class InlinedMethodCallers {
      */
     private static final Object[][] BOOT_IMAGE = {
             // callers of Application#attach(Context)
+            {"android.app.LoadedApk", "makeApplication", Boolean.TYPE, Instrumentation.class},
+            {"android.app.LoadedApk", "makeApplicationInner", Boolean.TYPE, Instrumentation.class},
+            {"android.app.LoadedApk", "makeApplicationInner", Boolean.TYPE, Instrumentation.class, Boolean.TYPE},
             {"android.app.Instrumentation", "newApplication", ClassLoader.class, String.class, Context.class},
             {"android.app.Instrumentation", "newApplication", ClassLoader.class, Context.class},
             {"android.app.ContextImpl", "getSharedPreferencesPath", String.class}


### PR DESCRIPTION
This fixes modules like OxygenCustomiser.