### PR TITLE
Fix memory leak by releasing JNI global refs in legacy_callbacks

### DIFF
--- a/core/src/main/jni/src/jni/hook_bridge.cpp
+++ b/core/src/main/jni/src/jni/hook_bridge.cpp
@@ -154,6 +154,7 @@ LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, unhookMethod, jboolean useModernApi,
     } else {
         for (auto i = hook_item->legacy_callbacks.begin(); i != hook_item->legacy_callbacks.end(); ++i) {
             if (env->IsSameObject(i->second, callback)) {
+                env->DeleteGlobalRef(i->second);
                 hook_item->legacy_callbacks.erase(i);
                 return JNI_TRUE;
             }


### PR DESCRIPTION
This commit as been taken from LSPosed-Irena.